### PR TITLE
eip158 fix

### DIFF
--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -106,6 +106,10 @@ func NewEVMInterpreter(evm *EVM, cfg Config) *EVMInterpreter {
 			jt = constantinopleInstructionSet
 		case evm.chainRules.IsByzantium:
 			jt = byzantiumInstructionSet
+			if !evm.chainRules.IsEIP158 {
+				// check EIP158
+				jt[EXP].dynamicGas = gasExpFrontier
+			}
 		case evm.chainRules.IsEIP158:
 			jt = spuriousDragonInstructionSet
 		case evm.chainRules.IsEIP150:


### PR DESCRIPTION
geth 1.9.x 기반부터 full sync를 하는 경우 `BAD BLOCK` 오류가 나고 있습니다.

이를 추적해보니 ESN의 경우에는 비잔티움 포크를 먼저 했고 나중에 eip158 적용이 되었는데,
이더리움의 경우에는 eip158이 먼저 적용된 이후에 비잔티움 포크가 이루어졌습니다.

이 패치는 비잔티움 포크가 된 이후 시점에도 eip158이 적용되지 않을 수도 있음을 체크하는 패치입니다.
(ESN의 경우 gas값을 여전히 예전 방식으로)

참고로 full sync를 하지 않고 fast sync를 하는 경우에는 `BAD BLOCK` 문제가 발생하지 않습니다.

cc: @ComBba , @turbobit 